### PR TITLE
runm3uatest: Avoid having to use a ~/.guile script

### DIFF
--- a/.guile
+++ b/.guile
@@ -1,0 +1,1 @@
+dotguile

--- a/dotguile
+++ b/dotguile
@@ -26,7 +26,7 @@
 ;;; $Id: dotguile,v 1.1 2012/08/26 21:06:27 tuexen Exp $
 
 ;;; Change the following line to reflect where the files are located.
-(define dir "/Users/tuexen/Documents/m3ua-testtool/")
+(define dir "")
 (define files (list "common.scm"
                     "m3ua.scm"
                     "m3ua-asp-tests.scm"

--- a/run-some-asp-tests
+++ b/run-some-asp-tests
@@ -16,6 +16,6 @@ testcases='m3ua-asp-aspsm-v-002
 
 for testcase in $testcases
 do
-  runm3uatest -t $timeout $testcase 2> /dev/null
+  ./runm3uatest -d . -t $timeout $testcase 2> /dev/null
   sleep $sleeptime
 done

--- a/run-some-sgp-tests
+++ b/run-some-sgp-tests
@@ -16,6 +16,6 @@ testcases='m3ua-sgp-aspsm-v-003
 
 for testcase in $testcases
 do
-  runm3uatest -t $timeout $testcase 2> /dev/null
+  ./runm3uatest -d . -t $timeout $testcase 2> /dev/null
   sleep $sleeptime
 done

--- a/runm3uatest.c
+++ b/runm3uatest.c
@@ -71,10 +71,11 @@ main(int argc, char *argv[]) {
 	unsigned int timeout;
 	int status, c;
 	char command[COMMAND_LENGTH];
+	char *dir = getenv("HOME");
 
 	timeout = TIMEOUT;
 
-	while ((c = getopt(argc, argv, "t:")) != -1) {
+	while ((c = getopt(argc, argv, "t:d:")) != -1) {
 		switch(c) {
 			case 'h':
 				print_usage();
@@ -83,6 +84,9 @@ main(int argc, char *argv[]) {
 			case 't':
 				timeout = (unsigned int)atoi(optarg);
 				break;
+			case 'd':
+				dir = optarg;
+				break;
 			default:
 				print_usage();
 				return (1);
@@ -90,7 +94,7 @@ main(int argc, char *argv[]) {
 	}
 
 	if (optind == argc - 1) {
-		snprintf(command, COMMAND_LENGTH, command_skel, getenv("HOME"), argv[optind]);
+		snprintf(command, COMMAND_LENGTH, command_skel, dir, argv[optind]);
 	} else {
 		print_usage();
 		return (1);
@@ -98,9 +102,9 @@ main(int argc, char *argv[]) {
 
 	if ((pid = fork()) == 0) {
 #if defined(__APPLE__) || defined(__FreeBSD__)
-		execlp("/usr/local/bin/guile", "guile", "-c", command, NULL);
+		execlp("/usr/local/bin/guile", "guile", "-L", dir, "-c", command, NULL);
 #else
-		execlp("/usr/bin/guile", "guile", "-c", command, NULL);
+		execlp("/usr/bin/guile", "guile", "-L", dir, "-c", command, NULL);
 #endif
 		return (255);
 	}


### PR DESCRIPTION
Rather, we can specify the path in which the m3ua-testtool files are
located using the '-d ...' command line argument of runm3uatest